### PR TITLE
feat: Phase 2 - Use configured extraction rules (Issue #71)

### DIFF
--- a/src/lib/agents/config/default-agent-configs.ts
+++ b/src/lib/agents/config/default-agent-configs.ts
@@ -12,7 +12,6 @@ export interface AgentDefaultConfig {
   };
   extractionRules: Record<string, {
     type: 'string' | 'number' | 'boolean' | 'array';
-    pattern?: string;
     patterns?: string[];
     required?: boolean;
     description?: string;
@@ -89,13 +88,13 @@ Your objectives:
       },
       team_size: {
         type: 'number',
-        pattern: "(\\d+)\\s*(?:people|members|employees|staff|direct reports|folks|individuals)",
+        patterns: ["(\\d+)\\s*(?:people|members|employees|staff|direct reports|folks|individuals)"],
         required: true,
         description: 'Extract the number of team members'
       },
       team_tenure: {
         type: 'string',
-        pattern: "(\\d+)\\s*(?:years?|months?|weeks?)\\s*(?:managing|leading|with)?",
+        patterns: ["(\\d+)\\s*(?:years?|months?|weeks?)\\s*(?:managing|leading|with)?"],
         required: true,
         description: 'How long they\'ve been managing the team'
       },
@@ -110,25 +109,25 @@ Your objectives:
       },
       success_metrics: {
         type: 'array',
-        pattern: "(?:success|goal|objective|outcome)\\s+(?:would be|is|means)\\s+(.+)",
+        patterns: ["(?:success|goal|objective|outcome)\\s+(?:would be|is|means)\\s+(.+)"],
         required: true,
         description: 'How they define success'
       },
       timeline_preference: {
         type: 'string',
-        pattern: "(\\d+)\\s*(?:weeks?|months?|quarters?|years?)\\s*(?:timeline|timeframe|to see results)?",
+        patterns: ["(\\d+)\\s*(?:weeks?|months?|quarters?|years?)\\s*(?:timeline|timeframe|to see results)?"],
         required: true,
         description: 'Preferred timeline for transformation'
       },
       budget_range: {
         type: 'string',
-        pattern: "(?:\\$|dollar|budget|invest)\\s*([0-9,]+(?:k|K|thousand|million)?)",
+        patterns: ["(?:\\$|dollar|budget|invest)\\s*([0-9,]+(?:k|K|thousand|million)?)"],
         required: true,
         description: 'Budget range for transformation'
       },
       leader_commitment: {
         type: 'string',
-        pattern: "(?:commit|dedicate|spend)\\s*(.+?)\\s*(?:hours?|time|per week|weekly)",
+        patterns: ["(?:commit|dedicate|spend)\\s*(.+?)\\s*(?:hours?|time|per week|weekly)"],
         required: true,
         description: 'Time commitment from leader'
       }

--- a/src/lib/agents/extraction/__tests__/extraction-processor.test.ts
+++ b/src/lib/agents/extraction/__tests__/extraction-processor.test.ts
@@ -1,0 +1,252 @@
+import { ExtractionProcessor, ExtractionRule } from '../extraction-processor';
+import { VariableExtractionService } from '../../../services/variable-extraction';
+
+// Mock the VariableExtractionService
+jest.mock('../../../services/variable-extraction', () => ({
+  VariableExtractionService: {
+    trackExtractionBatch: jest.fn().mockResolvedValue(0)
+  }
+}));
+
+describe('ExtractionProcessor', () => {
+  let originalEnv: string | undefined;
+
+  beforeAll(() => {
+    // Save original NODE_ENV
+    originalEnv = process.env.NODE_ENV;
+    // Set NODE_ENV to 'development' to enable tracking in tests
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterAll(() => {
+    // Restore original NODE_ENV
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('extractFromMessage', () => {
+    it('should extract string fields with patterns', () => {
+      const rules: Record<string, ExtractionRule> = {
+        manager_name: {
+          type: 'string',
+          patterns: [
+            "(?:I'm|I am|My name is)\\s+([A-Z][a-z]+(?:\\s+[A-Z][a-z]+)?)"
+          ],
+          required: true
+        }
+      };
+
+      const message = "Hi, I'm Sarah Johnson from TechCorp";
+      const results = ExtractionProcessor.extractFromMessage(message, rules);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        fieldName: 'manager_name',
+        attempted: true,
+        successful: true,
+        extractedValue: 'Sarah Johnson',
+        confidence: expect.any(Number)
+      });
+    });
+
+    it('should extract number fields', () => {
+      const rules: Record<string, ExtractionRule> = {
+        team_size: {
+          type: 'number',
+          patterns: [
+            "(\\d+)\\s*(?:people|members|employees)"
+          ]
+        }
+      };
+
+      const message = "We have 25 people on our team";
+      const results = ExtractionProcessor.extractFromMessage(message, rules);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        fieldName: 'team_size',
+        attempted: true,
+        successful: true,
+        extractedValue: 25,
+        confidence: expect.any(Number)
+      });
+    });
+
+    it('should handle multiple patterns for a field', () => {
+      const rules: Record<string, ExtractionRule> = {
+        organization: {
+          type: 'string',
+          patterns: [
+            "(?:work at|from)\\s+([A-Za-z0-9]+)",
+            "(?:company|org)\\s+(?:is|called)\\s+([A-Za-z0-9]+)"
+          ]
+        }
+      };
+
+      const message1 = "I work at Microsoft";
+      const results1 = ExtractionProcessor.extractFromMessage(message1, rules);
+      expect(results1[0].extractedValue).toBe('Microsoft');
+
+      const message2 = "My company is Apple";
+      const results2 = ExtractionProcessor.extractFromMessage(message2, rules);
+      expect(results2[0].extractedValue).toBe('Apple');
+    });
+
+    it('should mark field as attempted but not successful when no match', () => {
+      const rules: Record<string, ExtractionRule> = {
+        budget: {
+          type: 'string',
+          patterns: ["\\$([\\d,]+)"]
+        }
+      };
+
+      const message = "We don't have a specific budget yet";
+      const results = ExtractionProcessor.extractFromMessage(message, rules);
+
+      expect(results[0]).toMatchObject({
+        fieldName: 'budget',
+        attempted: true,
+        successful: false,
+        confidence: 0
+      });
+    });
+
+    it('should handle fields with no patterns', () => {
+      const rules: Record<string, ExtractionRule> = {
+        notes: {
+          type: 'string',
+          description: 'General notes'
+          // No patterns defined
+        }
+      };
+
+      const message = "Some random text";
+      const results = ExtractionProcessor.extractFromMessage(message, rules);
+
+      expect(results[0]).toMatchObject({
+        fieldName: 'notes',
+        attempted: true,
+        successful: false,
+        confidence: 0
+      });
+    });
+
+    it('should handle invalid regex patterns gracefully', () => {
+      const rules: Record<string, ExtractionRule> = {
+        invalid: {
+          type: 'string',
+          patterns: ["[invalid(regex"]
+        }
+      };
+
+      const message = "Test message";
+      const results = ExtractionProcessor.extractFromMessage(message, rules);
+
+      expect(results[0]).toMatchObject({
+        fieldName: 'invalid',
+        attempted: true,
+        successful: false
+      });
+    });
+  });
+
+  describe('confidence calculation', () => {
+    it('should give higher confidence for matches at the beginning', () => {
+      const rules: Record<string, ExtractionRule> = {
+        name: {
+          type: 'string',
+          patterns: ["([A-Z][a-z]+)"]
+        }
+      };
+
+      const message1 = "John is my name";
+      const message2 = "My name is John but people call me Johnny";
+      
+      const results1 = ExtractionProcessor.extractFromMessage(message1, rules);
+      const results2 = ExtractionProcessor.extractFromMessage(message2, rules);
+
+      // Both should have confidence scores
+      expect(results1[0].confidence).toBeGreaterThan(0);
+      expect(results2[0].confidence).toBeGreaterThan(0);
+      
+      // First match "John" at position 0 should have higher confidence than later match
+      // Since "John" appears at position 0 in message1 and position 11 in message2
+      expect(results1[0].confidence).toBeGreaterThanOrEqual(results2[0].confidence!);
+    });
+  });
+
+  describe('extractAndTrack', () => {
+    it('should extract and track extractions', async () => {
+      const rules: Record<string, ExtractionRule> = {
+        name: {
+          type: 'string',
+          patterns: ["I'm\\s+([A-Z][a-z]+)"]
+        },
+        team_size: {
+          type: 'number',
+          patterns: ["(\\d+)\\s+people"]
+        }
+      };
+
+      const context = {
+        conversationId: 'conv-123',
+        agentName: 'TestAgent'
+      };
+
+      const message = "I'm Bob and we have 10 people";
+      const { extracted, results } = await ExtractionProcessor.extractAndTrack(
+        message,
+        rules,
+        context
+      );
+
+      expect(extracted).toEqual({
+        name: 'Bob',
+        team_size: 10
+      });
+
+      expect(results).toHaveLength(2);
+      expect(VariableExtractionService.trackExtractionBatch).toHaveBeenCalled();
+    });
+
+    it('should not track in test environment', async () => {
+      const oldEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
+
+      try {
+        const rules: Record<string, ExtractionRule> = {
+          name: { type: 'string', patterns: ["I'm\\s+([A-Z][a-z]+)"] }
+        };
+
+        const context = {
+          conversationId: 'conv-123',
+          agentName: 'TestAgent'
+        };
+
+        await ExtractionProcessor.extractAndTrack("I'm Alice", rules, context);
+        
+        expect(VariableExtractionService.trackExtractionBatch).not.toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = oldEnv;
+      }
+    });
+
+    it('should not track test conversation IDs', async () => {
+      const rules: Record<string, ExtractionRule> = {
+        name: { type: 'string', patterns: ["I'm\\s+([A-Z][a-z]+)"] }
+      };
+
+      const context = {
+        conversationId: 'test-123',
+        agentName: 'TestAgent'
+      };
+
+      await ExtractionProcessor.extractAndTrack("I'm Bob", rules, context);
+      
+      expect(VariableExtractionService.trackExtractionBatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/agents/extraction/extraction-processor.ts
+++ b/src/lib/agents/extraction/extraction-processor.ts
@@ -1,0 +1,208 @@
+import { VariableExtractionService, VariableExtractionInput } from '../../services/variable-extraction';
+
+export interface ExtractionRule {
+  type: 'string' | 'number' | 'boolean' | 'array';
+  patterns?: string[];
+  required?: boolean;
+  description?: string;
+}
+
+export interface ExtractionResult {
+  fieldName: string;
+  attempted: boolean;
+  successful: boolean;
+  extractedValue?: any;
+  confidence?: number;
+  pattern?: string;
+}
+
+export interface ExtractionContext {
+  conversationId: string;
+  agentName: string;
+  teamId?: string;
+  managerId?: string;
+}
+
+export class ExtractionProcessor {
+  /**
+   * Extract variables from a message using configured extraction rules
+   */
+  static extractFromMessage(
+    message: string, 
+    rules: Record<string, ExtractionRule>
+  ): ExtractionResult[] {
+    const results: ExtractionResult[] = [];
+
+    for (const [fieldName, rule] of Object.entries(rules)) {
+      const result = this.extractField(message, fieldName, rule);
+      results.push(result);
+    }
+
+    return results;
+  }
+
+  /**
+   * Extract a single field using its rule configuration
+   */
+  private static extractField(
+    message: string,
+    fieldName: string,
+    rule: ExtractionRule
+  ): ExtractionResult {
+    // If no patterns defined, mark as attempted but not successful
+    if (!rule.patterns || rule.patterns.length === 0) {
+      return {
+        fieldName,
+        attempted: true,
+        successful: false,
+        confidence: 0
+      };
+    }
+
+    // Try each pattern
+    for (const pattern of rule.patterns) {
+      try {
+        const regex = new RegExp(pattern, 'i');
+        const match = message.match(regex);
+
+        if (match) {
+          let extractedValue: any;
+
+          // Extract based on type
+          switch (rule.type) {
+            case 'number':
+              // Extract the first capture group or the full match
+              const numStr = match[1] || match[0];
+              extractedValue = parseInt(numStr.replace(/[^\d]/g, ''), 10);
+              if (isNaN(extractedValue)) {
+                continue; // Try next pattern
+              }
+              break;
+
+            case 'boolean':
+              // For boolean, just check if pattern matched
+              extractedValue = true;
+              break;
+
+            case 'array':
+              // For arrays, extract all capture groups
+              extractedValue = match.slice(1).filter(Boolean);
+              break;
+
+            case 'string':
+            default:
+              // Extract first capture group or full match
+              extractedValue = match[1] || match[0];
+              break;
+          }
+
+          // Calculate confidence based on match quality
+          const confidence = this.calculateConfidence(match, pattern, message);
+
+          return {
+            fieldName,
+            attempted: true,
+            successful: true,
+            extractedValue,
+            confidence,
+            pattern
+          };
+        }
+      } catch (error) {
+        console.error(`Invalid regex pattern for field ${fieldName}: ${pattern}`, error);
+      }
+    }
+
+    // No patterns matched
+    return {
+      fieldName,
+      attempted: true,
+      successful: false,
+      confidence: 0
+    };
+  }
+
+  /**
+   * Calculate confidence score for an extraction
+   */
+  private static calculateConfidence(
+    match: RegExpMatchArray,
+    pattern: string,
+    message: string
+  ): number {
+    // Base confidence of 0.6 for any match
+    let confidence = 0.6;
+
+    // Boost confidence for exact pattern matches
+    if (match[0].length === message.length) {
+      confidence += 0.2;
+    }
+
+    // Boost confidence for matches with multiple captured groups
+    if (match.length > 2) {
+      confidence += 0.1;
+    }
+
+    // Boost confidence if match is near the beginning of the message
+    if (match.index !== undefined && match.index < 20) {
+      confidence += 0.1;
+    }
+
+    return Math.min(confidence, 1.0);
+  }
+
+  /**
+   * Track extraction results to the database
+   */
+  static async trackExtractions(
+    results: ExtractionResult[],
+    context: ExtractionContext
+  ): Promise<void> {
+    const extractionInputs: VariableExtractionInput[] = results.map(result => ({
+      conversationId: context.conversationId,
+      agentName: context.agentName,
+      fieldName: result.fieldName,
+      attempted: result.attempted,
+      successful: result.successful,
+      extractedValue: result.extractedValue ? String(result.extractedValue) : undefined,
+      confidence: result.confidence
+    }));
+
+    // Only track if we have results and a valid conversation ID
+    if (extractionInputs.length > 0 && context.conversationId && 
+        !context.conversationId.startsWith('test-') && 
+        process.env.NODE_ENV !== 'test') {
+      try {
+        await VariableExtractionService.trackExtractionBatch(extractionInputs);
+      } catch (error) {
+        console.error('Failed to track extractions:', error);
+        // Don't throw - extraction tracking should not break the main flow
+      }
+    }
+  }
+
+  /**
+   * Extract and track in one operation
+   */
+  static async extractAndTrack(
+    message: string,
+    rules: Record<string, ExtractionRule>,
+    context: ExtractionContext
+  ): Promise<{ extracted: Record<string, any>; results: ExtractionResult[] }> {
+    // Extract from message
+    const results = this.extractFromMessage(message, rules);
+
+    // Build extracted values object
+    const extracted: Record<string, any> = {};
+    for (const result of results) {
+      if (result.successful && result.extractedValue !== undefined) {
+        extracted[result.fieldName] = result.extractedValue;
+      }
+    }
+
+    // Track extractions
+    await this.trackExtractions(results, context);
+
+    return { extracted, results };
+  }
+}

--- a/src/lib/agents/implementations/__tests__/onboarding-agent-extraction.test.ts
+++ b/src/lib/agents/implementations/__tests__/onboarding-agent-extraction.test.ts
@@ -23,10 +23,8 @@ jest.mock('../../llm', () => ({
 }));
 
 // Mock the knowledge base
-jest.mock('../../knowledge/knowledge-base', () => ({
-  KnowledgeBase: jest.fn().mockImplementation(() => ({
-    search: jest.fn().mockResolvedValue([])
-  }))
+jest.mock('../../../knowledge-base', () => ({
+  knowledgeBaseTools: []
 }));
 
 describe('OnboardingAgent Extraction with Configuration', () => {

--- a/src/lib/agents/implementations/__tests__/onboarding-agent-extraction.test.ts
+++ b/src/lib/agents/implementations/__tests__/onboarding-agent-extraction.test.ts
@@ -1,0 +1,180 @@
+import { OnboardingAgent } from '../onboarding-agent';
+import { AgentContext } from '../../types';
+import { VariableExtractionService } from '../../../services/variable-extraction';
+import { AgentConfigLoader } from '../../config/agent-config-loader';
+
+// Mock dependencies
+jest.mock('../../../services/variable-extraction', () => ({
+  VariableExtractionService: {
+    trackExtractionBatch: jest.fn().mockResolvedValue(0)
+  }
+}));
+
+jest.mock('../../config/agent-config-loader');
+
+// Mock the LLM provider
+jest.mock('../../llm', () => ({
+  LLMProvider: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue({
+      content: 'Mocked response',
+      toolCalls: []
+    })
+  }))
+}));
+
+// Mock the knowledge base
+jest.mock('../../knowledge/knowledge-base', () => ({
+  KnowledgeBase: jest.fn().mockImplementation(() => ({
+    search: jest.fn().mockResolvedValue([])
+  }))
+}));
+
+describe('OnboardingAgent Extraction with Configuration', () => {
+  let agent: OnboardingAgent;
+  let mockContext: AgentContext;
+  let originalEnv: string | undefined;
+
+  beforeAll(() => {
+    originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    // Set OpenAI key to avoid initialization error
+    process.env.OPENAI_API_KEY = 'test-key';
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Mock the config loader to return configured extraction rules
+    (AgentConfigLoader.loadConfiguration as jest.Mock).mockResolvedValue({
+      systemPrompt: 'Test prompt',
+      extractionRules: {
+        manager_name: {
+          type: 'string',
+          patterns: ["I'm\\s+([A-Z][a-z]+)"],
+          required: true
+        },
+        team_size: {
+          type: 'number',
+          patterns: ["(\\d+)\\s+people"],
+          required: true
+        }
+      }
+    });
+
+    // Mock getDefaultExtractionRules as fallback
+    (AgentConfigLoader.getDefaultExtractionRules as jest.Mock).mockReturnValue({
+      manager_name: {
+        type: 'string',
+        patterns: ["My name is\\s+([A-Z][a-z]+)"],
+        required: true
+      }
+    });
+
+    agent = new OnboardingAgent();
+    mockContext = {
+      conversationId: 'conv-123',
+      managerId: 'manager-123',
+      teamId: 'team-123',
+      messageHistory: [],
+      metadata: {}
+    };
+  });
+
+  test('should use configured extraction rules', async () => {
+    const message = "I'm Bob and we have 15 people on the team";
+    
+    // Call processMessage to trigger extraction
+    await agent.processMessage(message, mockContext);
+
+    // Verify config was loaded
+    expect(AgentConfigLoader.loadConfiguration).toHaveBeenCalledWith('OnboardingAgent');
+
+    // Verify extraction tracking was called
+    expect(VariableExtractionService.trackExtractionBatch).toHaveBeenCalled();
+    
+    const trackedExtractions = (VariableExtractionService.trackExtractionBatch as jest.Mock).mock.calls[0][0];
+    
+    // Should have tracked both configured fields
+    expect(trackedExtractions).toHaveLength(2);
+    
+    // Check manager_name extraction
+    const nameExtraction = trackedExtractions.find((e: any) => e.fieldName === 'manager_name');
+    expect(nameExtraction).toMatchObject({
+      fieldName: 'manager_name',
+      attempted: true,
+      successful: true,
+      extractedValue: 'Bob'
+    });
+
+    // Check team_size extraction  
+    const sizeExtraction = trackedExtractions.find((e: any) => e.fieldName === 'team_size');
+    expect(sizeExtraction).toMatchObject({
+      fieldName: 'team_size',
+      attempted: true,
+      successful: true,
+      extractedValue: '15'
+    });
+  });
+
+  test('should fall back to default rules when no config', async () => {
+    // Mock no configuration found
+    (AgentConfigLoader.loadConfiguration as jest.Mock).mockResolvedValue(null);
+
+    const message = "My name is Alice";
+    
+    await agent.processMessage(message, mockContext);
+
+    // Should have used default rules
+    expect(AgentConfigLoader.getDefaultExtractionRules).toHaveBeenCalledWith('OnboardingAgent');
+    
+    // Verify extraction still happened
+    expect(VariableExtractionService.trackExtractionBatch).toHaveBeenCalled();
+  });
+
+  test('should maintain backward compatibility with metadata', async () => {
+    const message = "I'm Sarah with 20 people";
+    
+    const response = await agent.processMessage(message, mockContext);
+
+    // Check that metadata is properly updated
+    expect(mockContext.metadata.onboarding).toBeDefined();
+    expect(mockContext.metadata.onboarding.capturedFields).toMatchObject({
+      manager_name: 'Sarah',
+      team_size: 20
+    });
+
+    // Check extraction tracking count in metadata
+    expect(mockContext.metadata.extractionsTracked).toBe(2);
+  });
+
+  test('should handle extraction errors gracefully', async () => {
+    // Mock config loader to throw error
+    (AgentConfigLoader.loadConfiguration as jest.Mock).mockRejectedValue(new Error('Config error'));
+
+    const message = "I'm John with 10 people";
+    
+    // Should not throw
+    const response = await agent.processMessage(message, mockContext);
+    
+    expect(response).toBeDefined();
+    
+    // Should fall back to default rules
+    expect(AgentConfigLoader.getDefaultExtractionRules).toHaveBeenCalled();
+  });
+
+  test('should not track in test environment', async () => {
+    const testContext = {
+      ...mockContext,
+      conversationId: 'test-123'
+    };
+
+    await agent.processMessage("I'm Test User", testContext);
+    
+    // Should not track test conversations
+    expect(VariableExtractionService.trackExtractionBatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Overview
This PR implements Phase 2 of Issue #71: Replace hardcoded extraction patterns with configured extraction rules.

## Changes Made

### 1. Created ExtractionProcessor Class
- New centralized extraction logic in `src/lib/agents/extraction/extraction-processor.ts`
- Handles pattern matching, type conversion, and confidence scoring
- Integrates with VariableExtractionService for tracking

### 2. Updated OnboardingAgent
- Modified `extractInformation()` to use ExtractionProcessor
- Loads extraction rules from AgentConfigLoader
- Falls back to default rules if no configuration exists
- Maintains backward compatibility with existing functionality

### 3. Normalized Extraction Rule Format
- Updated default configs to use consistent `patterns` array format
- Supports multiple patterns per field for flexibility
- Each rule includes type, patterns, required flag, and description

### 4. Fixed Variable System Discrepancy
- Removed hardcoded REQUIRED_FIELDS array from OnboardingAgent
- Now uses extraction rules to determine required fields dynamically
- Ensures /admin/conversations shows same fields as /admin/agents/config
- All required field logic now comes from configured extraction rules

### 5. Comprehensive Testing
- Added tests for ExtractionProcessor
- Added tests for OnboardingAgent with configured rules
- Tests cover success cases, failures, and fallback scenarios

## Benefits
- ✅ Extraction patterns can be modified without code changes
- ✅ Admins can configure extraction rules via /admin/agents/config
- ✅ Consistent variable system across admin interfaces
- ✅ Better maintainability and flexibility
- ✅ Foundation for future enhancements (UI controls, LLM fallback)

## Testing
1. Run tests: `npm test`
2. Test extraction in chat with various inputs
3. Verify extraction rules can be modified in /admin/agents/config
4. Check that /admin/conversations shows correct required fields

## Related Issues
- Closes #71
- Related future enhancements tracked in #74, #75, #76, #77

## Screenshots
The Variable Extraction Analytics dashboard continues to work as before, now tracking extractions based on configured rules.