### PR TITLE
Fix: LLM asks for already-extracted information

### DIFF
--- a/src/lib/agents/config/default-agent-configs.ts
+++ b/src/lib/agents/config/default-agent-configs.ts
@@ -34,7 +34,14 @@ Your objectives:
 - Discuss practical considerations and resources
 - Identify key stakeholders
 - Extract required information naturally through conversation
-- Prepare for handoff to Assessment Agent when ready`,
+- Prepare for handoff to Assessment Agent when ready
+
+IMPORTANT INSTRUCTIONS:
+- Always check the "Already captured information" section in your context before asking any questions
+- NEVER ask for information that has already been captured
+- Focus only on gathering the missing required fields listed in "Still need to capture"
+- If the user provides information naturally, acknowledge it rather than asking for it again
+- Be conversational and natural while being efficient in gathering missing information`,
       greeting: "Welcome to TMS! I'm excited to help you transform your team. I'm your dedicated guide through this journey. What's your name, and what brings you to TMS today?",
       context_discovery: "Tell me about your team - how many people do you manage, and how long have you been leading this group? I'd love to understand your team's structure and dynamics.",
       challenge_exploration: "What specific challenges is your team facing right now? How are these impacting your team's performance and your goals?",

--- a/src/lib/agents/implementations/__tests__/onboarding-agent-context.test.ts
+++ b/src/lib/agents/implementations/__tests__/onboarding-agent-context.test.ts
@@ -1,0 +1,185 @@
+import { OnboardingAgent } from '../onboarding-agent';
+import { AgentContext } from '../../types';
+
+// Mock dependencies
+jest.mock('../../../services/variable-extraction', () => ({
+  VariableExtractionService: {
+    trackExtractionBatch: jest.fn().mockResolvedValue(0)
+  }
+}));
+
+jest.mock('../../config/agent-config-loader');
+
+// Mock the LLM provider
+jest.mock('../../llm', () => ({
+  LLMProvider: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue({
+      content: 'Mocked response',
+      toolCalls: []
+    })
+  }))
+}));
+
+// Mock the knowledge base
+jest.mock('../../../knowledge-base', () => ({
+  knowledgeBaseTools: []
+}));
+
+describe('OnboardingAgent Context Prompt', () => {
+  let agent: OnboardingAgent;
+  let mockContext: AgentContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    agent = new OnboardingAgent();
+  });
+
+  test('should include captured fields in context prompt', () => {
+    mockContext = {
+      conversationId: 'test-123',
+      managerId: 'manager-123',
+      teamId: 'team-123',
+      messageHistory: [],
+      metadata: {
+        onboarding: {
+          state: 'context_discovery',
+          startTime: new Date(),
+          capturedFields: {
+            manager_name: 'John Smith',
+            team_size: 15,
+            organization: 'TechCorp'
+          },
+          requiredFieldsStatus: {
+            manager_name: true,
+            team_size: true,
+            organization: false,
+            team_tenure: false,
+            primary_challenge: false
+          },
+          qualityMetrics: {
+            rapportScore: 0,
+            managerConfidence: 'low',
+            completionPercentage: 40
+          },
+          stateTransitions: []
+        }
+      }
+    };
+
+    // Access the protected method via type assertion
+    const contextPrompt = (agent as any).buildContextPrompt(mockContext);
+
+    // Verify captured fields are included
+    expect(contextPrompt).toContain('Already captured information:');
+    expect(contextPrompt).toContain('Manager Name: John Smith');
+    expect(contextPrompt).toContain('Team Size: 15');
+    expect(contextPrompt).toContain('Organization: TechCorp');
+
+    // Verify important instruction is included
+    expect(contextPrompt).toContain('IMPORTANT: Do not ask for information that has already been captured above');
+
+    // Verify missing fields are listed
+    expect(contextPrompt).toContain('Still need to capture:');
+    expect(contextPrompt).toContain('Team Tenure');
+    expect(contextPrompt).toContain('Primary Challenge');
+  });
+
+  test('should not add captured fields section when no fields are captured', () => {
+    mockContext = {
+      conversationId: 'test-456',
+      managerId: 'manager-456',
+      teamId: 'team-456',
+      messageHistory: [],
+      metadata: {
+        onboarding: {
+          state: 'greeting',
+          startTime: new Date(),
+          capturedFields: {},
+          requiredFieldsStatus: {
+            manager_name: false,
+            team_size: false,
+            team_tenure: false
+          },
+          qualityMetrics: {
+            rapportScore: 0,
+            managerConfidence: 'low',
+            completionPercentage: 0
+          },
+          stateTransitions: []
+        }
+      }
+    };
+
+    const contextPrompt = (agent as any).buildContextPrompt(mockContext);
+
+    // Should not contain captured fields section
+    expect(contextPrompt).not.toContain('Already captured information:');
+    
+    // Should still list fields to capture
+    expect(contextPrompt).toContain('Still need to capture:');
+    expect(contextPrompt).toContain('Manager Name');
+    expect(contextPrompt).toContain('Team Size');
+    expect(contextPrompt).toContain('Team Tenure');
+  });
+
+  test('should handle metadata without onboarding section gracefully', () => {
+    mockContext = {
+      conversationId: 'test-789',
+      managerId: 'manager-789',
+      teamId: 'team-789',
+      messageHistory: [],
+      metadata: {}
+    };
+
+    // Should not throw error
+    expect(() => {
+      (agent as any).buildContextPrompt(mockContext);
+    }).not.toThrow();
+
+    const contextPrompt = (agent as any).buildContextPrompt(mockContext);
+    
+    // Should not contain any onboarding-specific sections
+    expect(contextPrompt).not.toContain('Already captured information:');
+    expect(contextPrompt).not.toContain('Still need to capture:');
+  });
+
+  test('should format field names properly', () => {
+    mockContext = {
+      conversationId: 'test-999',
+      managerId: 'manager-999',
+      teamId: 'team-999',
+      messageHistory: [],
+      metadata: {
+        onboarding: {
+          state: 'context_discovery',
+          startTime: new Date(),
+          capturedFields: {
+            primary_challenge: 'Communication issues',
+            budget_range: '$50k-$100k',
+            leader_commitment: '5 hours per week'
+          },
+          requiredFieldsStatus: {
+            primary_challenge: true,
+            budget_range: true,
+            leader_commitment: true,
+            success_metrics: false
+          },
+          qualityMetrics: {
+            rapportScore: 0,
+            managerConfidence: 'medium',
+            completionPercentage: 75
+          },
+          stateTransitions: []
+        }
+      }
+    };
+
+    const contextPrompt = (agent as any).buildContextPrompt(mockContext);
+
+    // Check proper formatting of multi-word field names
+    expect(contextPrompt).toContain('Primary Challenge: Communication issues');
+    expect(contextPrompt).toContain('Budget Range: $50k-$100k');
+    expect(contextPrompt).toContain('Leader Commitment: 5 hours per week');
+    expect(contextPrompt).toContain('Success Metrics');
+  });
+});


### PR DESCRIPTION
## Overview
This PR fixes Issue #75 where the OnboardingAgent's LLM would ask users for information that had already been extracted via regex patterns.

## Problem
- User says "my team is 3 people"
- Regex successfully extracts `team_size: 3`
- LLM still asks "How many people are on your team?"
- This makes the system appear unintelligent

## Solution
1. **Override buildContextPrompt** in OnboardingAgent to include:
   - "Already captured information" section with extracted data
   - "Still need to capture" section with missing required fields
   
2. **Update system prompt** with clear instructions:
   - Always check captured information before asking questions
   - Never ask for already-captured data
   - Focus on missing required fields

## Changes
- Added `buildContextPrompt()` override in OnboardingAgent
- Updated default system prompt with extraction awareness instructions
- Added comprehensive tests for context prompt building

## Testing
1. Run tests: `npm test`
2. Test in chat - provide team size early and verify agent doesn't ask again
3. Check that context includes captured fields in LLM prompt

## Example Context Output
```
Already captured information:
- Team Size: 15
- Manager Name: John Smith

IMPORTANT: Do not ask for information that has already been captured above.

Still need to capture:
- Team Tenure
- Primary Challenge
```

## Benefits
- ✅ Eliminates duplicate questions
- ✅ Better user experience
- ✅ System appears more intelligent
- ✅ More efficient conversations

Fixes #75