### PR TITLE
feat: Implement simplified 4-phase journey system

### DIFF
--- a/components/admin/journey-details.tsx
+++ b/components/admin/journey-details.tsx
@@ -171,7 +171,34 @@ export function JourneyDetails({
           color: '#6b7280',
           textAlign: 'center'
         }}>
-          {progressPercentage}% Complete ({completedSteps.length} of {JOURNEY_STEPS.length} steps)
+          {progressPercentage}% Complete ({completedRequiredSteps.length} of {requiredSteps.length} required steps)
+        </div>
+      </div>
+
+      {/* Current Phase Indicator */}
+      <div style={{
+        marginBottom: '24px',
+        padding: '16px',
+        borderRadius: '8px',
+        backgroundColor: PHASE_CONFIG[currentPhase].bgColor,
+        border: `1px solid ${PHASE_CONFIG[currentPhase].color}40`
+      }}>
+        <div style={{
+          fontSize: '14px',
+          fontWeight: '600',
+          color: PHASE_CONFIG[currentPhase].color,
+          marginBottom: '4px'
+        }}>
+          Current Phase: {PHASE_CONFIG[currentPhase].label}
+        </div>
+        <div style={{
+          fontSize: '13px',
+          color: '#4b5563'
+        }}>
+          {currentPhase === JourneyPhase.ONBOARDING && 'Getting to know you and your team'}
+          {currentPhase === JourneyPhase.ASSESSMENT && 'Completing assessments to understand team dynamics'}
+          {currentPhase === JourneyPhase.DEBRIEF && 'Reviewing insights and creating action plans'}
+          {currentPhase === JourneyPhase.CONTINUOUS_ENGAGEMENT && 'Ongoing monitoring and improvement'}
         </div>
       </div>
 
@@ -240,14 +267,27 @@ export function JourneyDetails({
                 alignItems: 'flex-start',
                 marginBottom: '4px'
               }}>
-                <h4 style={{
-                  fontSize: '16px',
-                  fontWeight: '500',
-                  color: step.completed ? '#059669' : 
-                         currentStep?.id === step.id ? '#111827' : '#6b7280'
-                }}>
-                  {step.name}
-                </h4>
+                <div>
+                  <h4 style={{
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    color: step.completed ? '#059669' : 
+                           currentStep?.id === step.id ? '#111827' : '#6b7280',
+                    marginBottom: '2px'
+                  }}>
+                    {step.name}
+                  </h4>
+                  <span style={{
+                    fontSize: '11px',
+                    fontWeight: '500',
+                    padding: '2px 6px',
+                    borderRadius: '4px',
+                    backgroundColor: PHASE_CONFIG[step.phase].bgColor,
+                    color: PHASE_CONFIG[step.phase].color
+                  }}>
+                    {PHASE_CONFIG[step.phase].label}
+                  </span>
+                </div>
                 {step.timeSpent > 0 && (
                   <div style={{
                     display: 'flex',

--- a/lib/orchestrator/journey-phases.ts
+++ b/lib/orchestrator/journey-phases.ts
@@ -1,0 +1,233 @@
+// Journey phase definitions for the simplified 4-phase system
+export enum JourneyPhase {
+  ONBOARDING = 'ONBOARDING',
+  ASSESSMENT = 'ASSESSMENT', 
+  DEBRIEF = 'DEBRIEF',
+  CONTINUOUS_ENGAGEMENT = 'CONTINUOUS_ENGAGEMENT'
+}
+
+export enum UserRole {
+  MANAGER = 'MANAGER',
+  TEAM_MEMBER = 'TEAM_MEMBER'
+}
+
+export interface JourneyStep {
+  id: string;
+  name: string;
+  description: string;
+  phase: JourneyPhase;
+  agent: string;
+  required: boolean;
+  order: number;
+  roles: UserRole[]; // Which roles can access this step
+  prerequisites?: string[]; // Step IDs that must be completed first
+}
+
+// Define journey steps for the new 4-phase system
+export const JOURNEY_STEPS: JourneyStep[] = [
+  // Phase 1: Onboarding
+  {
+    id: 'welcome',
+    name: 'Welcome & Introduction',
+    description: 'Introduction to TeamOS and personalized journey setup',
+    phase: JourneyPhase.ONBOARDING,
+    agent: 'OnboardingAgent',
+    required: true,
+    order: 1,
+    roles: [UserRole.MANAGER, UserRole.TEAM_MEMBER]
+  },
+  {
+    id: 'manager_team_context',
+    name: 'Team Context & Challenges',
+    description: 'Gather information about your team, structure, and primary challenges',
+    phase: JourneyPhase.ONBOARDING,
+    agent: 'OnboardingAgent',
+    required: true,
+    order: 2,
+    roles: [UserRole.MANAGER]
+  },
+  {
+    id: 'member_role_context',
+    name: 'Role & Work Preferences',
+    description: 'Share your role, responsibilities, and work style preferences',
+    phase: JourneyPhase.ONBOARDING,
+    agent: 'OnboardingAgent',
+    required: true,
+    order: 2,
+    roles: [UserRole.TEAM_MEMBER]
+  },
+  {
+    id: 'manager_goals',
+    name: 'Transformation Goals',
+    description: 'Define your team transformation objectives and success metrics',
+    phase: JourneyPhase.ONBOARDING,
+    agent: 'OnboardingAgent',
+    required: true,
+    order: 3,
+    roles: [UserRole.MANAGER]
+  },
+
+  // Phase 2: Assessment
+  {
+    id: 'tmp_assessment',
+    name: 'Team Management Profile (TMP)',
+    description: 'Complete your personalized work personality assessment',
+    phase: JourneyPhase.ASSESSMENT,
+    agent: 'AssessmentAgent',
+    required: true,
+    order: 4,
+    roles: [UserRole.MANAGER, UserRole.TEAM_MEMBER],
+    prerequisites: ['welcome']
+  },
+  {
+    id: 'team_signals_baseline',
+    name: 'Team Signals Baseline',
+    description: 'Establish baseline team health metrics',
+    phase: JourneyPhase.ASSESSMENT,
+    agent: 'AssessmentAgent',
+    required: true,
+    order: 5,
+    roles: [UserRole.MANAGER],
+    prerequisites: ['tmp_assessment']
+  },
+
+  // Phase 3: Debrief
+  {
+    id: 'tmp_debrief',
+    name: 'TMP Personal Debrief',
+    description: 'Receive insights about your work personality and management style',
+    phase: JourneyPhase.DEBRIEF,
+    agent: 'DebriefAgent',
+    required: true,
+    order: 6,
+    roles: [UserRole.MANAGER, UserRole.TEAM_MEMBER],
+    prerequisites: ['tmp_assessment']
+  },
+  {
+    id: 'team_signals_debrief',
+    name: 'Team Health Insights',
+    description: 'Review team dynamics and health indicators',
+    phase: JourneyPhase.DEBRIEF,
+    agent: 'DebriefAgent',
+    required: true,
+    order: 7,
+    roles: [UserRole.MANAGER],
+    prerequisites: ['team_signals_baseline']
+  },
+
+  // Phase 4: Continuous Engagement
+  {
+    id: 'quarterly_team_signals',
+    name: 'Quarterly Team Signals',
+    description: 'Track team progress with quarterly health checks',
+    phase: JourneyPhase.CONTINUOUS_ENGAGEMENT,
+    agent: 'AssessmentAgent',
+    required: false,
+    order: 8,
+    roles: [UserRole.MANAGER, UserRole.TEAM_MEMBER],
+    prerequisites: ['team_signals_baseline']
+  },
+  {
+    id: 'advanced_assessments',
+    name: 'Advanced Assessments',
+    description: 'Access to WoWV, QO2, LLP 360 assessments as needed',
+    phase: JourneyPhase.CONTINUOUS_ENGAGEMENT,
+    agent: 'AssessmentAgent',
+    required: false,
+    order: 9,
+    roles: [UserRole.MANAGER],
+    prerequisites: ['tmp_debrief']
+  }
+];
+
+// Helper function to get steps for a specific role and phase
+export function getStepsForRole(role: UserRole, phase?: JourneyPhase): JourneyStep[] {
+  return JOURNEY_STEPS.filter(step => {
+    const roleMatch = step.roles.includes(role);
+    const phaseMatch = phase ? step.phase === phase : true;
+    return roleMatch && phaseMatch;
+  }).sort((a, b) => a.order - b.order);
+}
+
+// Helper function to get next available step
+export function getNextStep(
+  completedSteps: string[], 
+  role: UserRole,
+  currentPhase: JourneyPhase
+): JourneyStep | null {
+  const availableSteps = JOURNEY_STEPS.filter(step => {
+    // Check role
+    if (!step.roles.includes(role)) return false;
+    
+    // Check if already completed
+    if (completedSteps.includes(step.id)) return false;
+    
+    // Check prerequisites
+    if (step.prerequisites) {
+      const prereqsMet = step.prerequisites.every(prereq => 
+        completedSteps.includes(prereq)
+      );
+      if (!prereqsMet) return false;
+    }
+    
+    // For continuous engagement, only show if previous phases complete
+    if (step.phase === JourneyPhase.CONTINUOUS_ENGAGEMENT) {
+      const requiredStepsComplete = JOURNEY_STEPS
+        .filter(s => s.required && s.roles.includes(role))
+        .every(s => completedSteps.includes(s.id));
+      if (!requiredStepsComplete) return false;
+    }
+    
+    return true;
+  }).sort((a, b) => a.order - b.order);
+  
+  return availableSteps[0] || null;
+}
+
+// Helper to determine current phase based on completed steps
+export function getCurrentPhase(completedSteps: string[], role: UserRole): JourneyPhase {
+  const roleSteps = getStepsForRole(role);
+  
+  // Check each phase in order
+  const phases = [
+    JourneyPhase.ONBOARDING,
+    JourneyPhase.ASSESSMENT,
+    JourneyPhase.DEBRIEF,
+    JourneyPhase.CONTINUOUS_ENGAGEMENT
+  ];
+  
+  for (let i = phases.length - 1; i >= 0; i--) {
+    const phase = phases[i];
+    const phaseSteps = roleSteps.filter(s => s.phase === phase && s.required);
+    
+    // If any required step in this phase is complete, we're at least in this phase
+    if (phaseSteps.some(s => completedSteps.includes(s.id))) {
+      // Check if all required steps in this phase are complete
+      const allComplete = phaseSteps.every(s => completedSteps.includes(s.id));
+      
+      // If all complete and there's a next phase, we're in the next phase
+      if (allComplete && i < phases.length - 1) {
+        return phases[i + 1];
+      }
+      
+      return phase;
+    }
+  }
+  
+  // Default to onboarding if no steps completed
+  return JourneyPhase.ONBOARDING;
+}
+
+// Map legacy journey status to new phases
+export function mapLegacyStatusToPhase(
+  journeyStatus: 'ONBOARDING' | 'ACTIVE' | 'DORMANT',
+  completedSteps: string[],
+  role: UserRole
+): JourneyPhase {
+  if (journeyStatus === 'ONBOARDING') {
+    return JourneyPhase.ONBOARDING;
+  }
+  
+  // For ACTIVE or DORMANT, determine phase based on completed steps
+  return getCurrentPhase(completedSteps, role);
+}


### PR DESCRIPTION
## Summary
- Implements the simplified 4-phase journey system as designed in Issue #82
- Creates role-based journey paths for managers vs team members
- Updates UI to show new phase progression

## Changes
1. **New Journey Phase System** (`/lib/orchestrator/journey-phases.ts`)
   - 4 phases: Onboarding → Assessment → Debrief → Continuous Engagement
   - Role-based step filtering (managers get full journey, team members simplified)
   - Helper functions for phase detection and step progression

2. **Updated Journey Tracker** (`/lib/orchestrator/journey-tracker.ts`)
   - Added role support to journey tracking
   - Maps legacy status (ONBOARDING/ACTIVE/DORMANT) to new phases
   - Role-aware step progression logic

3. **Enhanced Onboarding Agent** (`/src/lib/agents/implementations/onboarding-agent.ts`)
   - Role-specific conversation flows and instructions
   - Different required fields for managers vs team members
   - Team members skip goal setting, resources, and stakeholder states

4. **Improved Admin UI** (`/components/admin/journey-details.tsx`)
   - Visual phase indicators with color coding
   - Role badges (Manager/Team Member)
   - Phase labels on each journey step
   - Current phase highlight box

## Journey Flows
### Manager Journey:
1. **Onboarding**: Welcome → Team Context → Goals
2. **Assessment**: TMP → Team Signals Baseline
3. **Debrief**: TMP Insights → Team Health Review
4. **Continuous**: Quarterly Team Signals → Advanced Assessments

### Team Member Journey:
1. **Onboarding**: Welcome → Role Context
2. **Assessment**: TMP only
3. **Debrief**: Personal TMP Insights
4. **Continuous**: Quarterly Team Signals

## Next Steps
- Implement assessment agent with TMP-first logic (#85)
- Create debrief agent for automated report generation (#86)
- Add team member invite system (#88)

Closes #82

🤖 Generated with [Claude Code](https://claude.ai/code)